### PR TITLE
[FEAT] Auth Package (Sign Out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,25 +39,37 @@ const config = {
 const auth = new Auth(config);
 
 // LOGIN
-// The auth.login method returns a promise with the firebase user data
 auth.login(email, password)
     .then((userData) => console.log(userData))
     .catch((error) => console.error(error));
 
+// The auth.login method returns a promise with the firebase user data
+
 // SIGN UP
-/* The auth.signUp method returns a promise with the user data
-  and sends a confirmation email using firebase
-  if the password and password confirmation match
-*/
 auth.signUp(email, password, passwordConfirmation)
     .then((userData) => console.log(userData))
     .catch((error) => console.error(error));
 
-/* if no password confirmation is provided or the passwords do not match
-  an error is thrown and the user is not signed up
+/* The auth.signUp method returns a promise with the user data
+  and sends a confirmation email using firebase
+  if the password and password confirmation match
 */
+
 // SIGN UP ERROR EXAMPLE
 auth.signUp("user@test.com", "password", "pswrd")
     .then((userData) => console.log(userData))
     .catch((error) => console.error(error)); // => Error: Passwords do not match
+
+/* If no password confirmation is provided or the passwords do not match
+  an error is thrown and the user is not signed up
+*/
+
+// SIGN OUT
+auth.signOut()
+    .then((response) => console.log(response)) // response => { success: true }
+    .catch((error) => console.error(error));
+
+/* On successful firebase sign out the auth.signOut method returns a promise which
+  resolves to a success object
+*/
 ```

--- a/packages/auth/src/auth.js
+++ b/packages/auth/src/auth.js
@@ -39,5 +39,17 @@ class Auth {
             throw new Error("Passwords do not match");
         }
     }
+    signOut() {
+        return new Promise((resolve, reject) => {
+            this.auth.signOut()
+                .then(() => {
+                // Sign-out successful
+                resolve({
+                    success: true
+                });
+            })
+                .catch((error) => reject(error.message));
+        });
+    }
 }
 exports.Auth = Auth;

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -38,4 +38,17 @@ export class Auth {
             throw new Error("Passwords do not match")
         }
     }
+
+    signOut() {
+        return new Promise((resolve: any, reject: any) => {
+            this.auth.signOut()
+            .then(() => {
+                // Sign-out successful
+                resolve({
+                    success: true
+                })
+            })
+            .catch((error: any) => reject(error.message))
+        })
+    }
 }

--- a/packages/auth/tests/auth.test.js
+++ b/packages/auth/tests/auth.test.js
@@ -13,6 +13,9 @@ describe("Auth Class", () => {
     const mockConfig = {
         apiKey: "apiKey",
     };
+
+    // MOCK FUNCTIONS
+
     // Mocking login function to return promise with user object
     Auth.prototype.login = jest.fn((email, password) => {
         if (email && password) {
@@ -31,6 +34,18 @@ describe("Auth Class", () => {
         }
     });
 
+    // Mocking signOut function to return promise with success object if firebase sign out is a success
+    Auth.prototype.signOut = jest.fn((success) => {
+        if (success) {
+            return Promise.resolve({
+                success: true,
+            });
+        } else {
+            throw new Error("Sign out failed");
+        }
+    });
+
+    // AUTH CLASS TESTS
     test("Auth class exists", () => {
         expect(Auth).toBeDefined();
     });
@@ -40,6 +55,8 @@ describe("Auth Class", () => {
 
         expect(auth).toBeDefined();
     });
+
+    // AUTH CLASS LOGIN METHOD TESTS
 
     test("Auth class instance login method returns user object with correct login arguments", async () => {
         const auth = new Auth(mockConfig);
@@ -55,6 +72,8 @@ describe("Auth Class", () => {
             auth.login();
         }).toThrow();
     });
+
+    // AUTH CLASS SIGNUP METHOD TESTS
 
     test("Auth class instance signUp method returns user object with correct signUp arguments", async () => {
         const auth = new Auth(mockConfig);
@@ -82,6 +101,23 @@ describe("Auth Class", () => {
         expect(() => {
             // No passwordConfirm provided
             auth.signUp("user@test.com", "userPassword");
+        }).toThrow();
+    });
+
+    // AUTH CLASS SIGNOUT METHOD TESTS
+
+    test("Auth class instance signOut method returns success object on successful sign out", async () => {
+        const auth = new Auth(mockConfig);
+        const result = await auth.signOut(true);
+
+        expect(result.success).toBeTruthy();
+    });
+
+    test("Auth class instance signOut method throws error when login fails", () => {
+        const auth = new Auth(mockConfig);
+
+        expect(() => {
+            auth.signOut(false);
         }).toThrow();
     });
 });


### PR DESCRIPTION
# Description

**Changes:** 

- Sign out method added (along with tests) for Auth class.
- README updated with Auth class sign out method usage.

**Usage:** 

```javascript
const { Auth } = require("@farisaziz12/web-core/packages/auth/src");
    
// Config object for firebase initialization 
const config = {
  apiKey: "firebaseApiKey",
};
    
auth.signOut()
    .then((response) => console.log(response)) // response => { success: true }
    .catch((error) => console.error(error));

/* On successful firebase sign out the auth.signOut method returns a promise which
   resolves to a success object
*/
```

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

run `npm test` to run all test suites

# Checklist (delete options that are not relevant):

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings or errors
-   [x] I have added test instructions that prove my fix is effective or that my feature works
